### PR TITLE
Forbid integrator init with a pars array of the wrong size

### DIFF
--- a/doc/breaking_changes.rst
+++ b/doc/breaking_changes.rst
@@ -8,6 +8,19 @@ Breaking changes
 6.0.0
 -----
 
+API/behaviour changes
+~~~~~~~~~~~~~~~~~~~~~
+
+In heyoka 6.0.0, the array of parameter values passed to the constructor
+of a Taylor integrator must either be empty (in which case the parameter
+values will be zero-inited), or it must have the correct size.
+
+In previous versions, heyoka would pad with zeroes the array of parameter values
+if its size was less than the correct one.
+
+General
+~~~~~~~
+
 - Support for LLVM<15 has been dropped.
 
 .. _bchanges_4_0_0:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -25,6 +25,12 @@ New
 Changes
 ~~~~~~~
 
+- **BREAKING**: the array of parameter values passed to the
+  constructor of a Taylor integrator must now either be empty
+  (in which case the parameter values will be zero-inited),
+  or have the correct size
+  (`#451 <https://github.com/bluescarni/heyoka/pull/451>`__).
+  This is a :ref:`breaking change <bchanges_6_0_0>`.
 - **BREAKING**: the minimum required LLVM version is now 15
   (`#444 <https://github.com/bluescarni/heyoka/pull/444>`__).
   This is a :ref:`breaking change <bchanges_6_0_0>`.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,7 +10,7 @@ New
 - It is now possible to initialise a Taylor integrator
   with an empty initial state vector. This will result
   in zero-initialization of the state vector
-  (`#449 <https://github.com/bluescarni/heyoka/pull/449 >`__).
+  (`#449 <https://github.com/bluescarni/heyoka/pull/449>`__).
 - Implement parallel compilation for Taylor integrators
   and compiled functions
   (`#446 <https://github.com/bluescarni/heyoka/pull/446>`__,

--- a/test/taylor_adaptive_batch.cpp
+++ b/test/taylor_adaptive_batch.cpp
@@ -950,9 +950,9 @@ TEST_CASE("cb interrupt")
     }
 }
 
-// Test excessive number of params provided upon construction
+// Test wrong number of params provided upon construction
 // of the integrator.
-TEST_CASE("param too many")
+TEST_CASE("param wrong number")
 {
     using Catch::Matchers::Message;
 
@@ -963,9 +963,9 @@ TEST_CASE("param too many")
                                                                 2u,
                                                                 kw::pars = std::vector{1., 2., 3.}}),
                            std::invalid_argument,
-                           Message("Excessive number of parameter values passed to the constructor of an adaptive "
+                           Message("Invalid number of parameter values passed to the constructor of an adaptive "
                                    "Taylor integrator in batch mode: 3 parameter value(s) were passed, but the ODE "
-                                   "system contains only 1 parameter(s) "
+                                   "system contains 1 parameter(s) "
                                    "(in batches of 2)"));
 
     REQUIRE_THROWS_MATCHES((void)(taylor_adaptive_batch<double>{{prime(x) = v, prime(v) = -9.8 * sin(x)},
@@ -974,10 +974,42 @@ TEST_CASE("param too many")
                                                                 kw::pars = std::vector{1., 2., 3.},
                                                                 kw::t_events = {t_event_batch<double>(v - par[0])}}),
                            std::invalid_argument,
-                           Message("Excessive number of parameter values passed to the constructor of an adaptive "
+                           Message("Invalid number of parameter values passed to the constructor of an adaptive "
                                    "Taylor integrator in batch mode: 3 parameter value(s) were passed, but the ODE "
-                                   "system contains only 1 parameter(s) "
+                                   "system contains 1 parameter(s) "
                                    "(in batches of 2)"));
+
+    REQUIRE_THROWS_MATCHES((void)(taylor_adaptive_batch<double>{{prime(x) = v + par[3], prime(v) = -9.8 * sin(x)},
+                                                                {0.05, 0.06, 0.025, 0.026},
+                                                                2u,
+                                                                kw::pars = std::vector{1., 2., 3.}}),
+                           std::invalid_argument,
+                           Message("Invalid number of parameter values passed to the constructor of an adaptive "
+                                   "Taylor integrator in batch mode: 3 parameter value(s) were passed, but the ODE "
+                                   "system contains 4 parameter(s) "
+                                   "(in batches of 2)"));
+}
+
+// Test to check that the parameter values are zeroed out
+// when an empty pars array is passed on construction.
+TEST_CASE("param auto setup")
+{
+    using Catch::Matchers::Message;
+
+    auto [x, v] = make_vars("x", "v");
+
+    auto ta = taylor_adaptive_batch<double>{{prime(x) = v, prime(v) = -9.8 * sin(x)},
+                                            {0.05, 0.06, 0.025, 0.026},
+                                            2u,
+                                            kw::t_events = {t_event_batch<double>(v - par[3])}};
+    REQUIRE(ta.get_pars() == std::vector{0., 0., 0., 0., 0., 0., 0., 0.});
+
+    ta = taylor_adaptive_batch<double>{{prime(x) = v, prime(v) = -9.8 * sin(x)},
+                                       {0.05, 0.06, 0.025, 0.026},
+                                       2u,
+                                       kw::pars = std::vector<double>{},
+                                       kw::t_events = {t_event_batch<double>(v - par[3])}};
+    REQUIRE(ta.get_pars() == std::vector{0., 0., 0., 0., 0., 0., 0., 0.});
 }
 
 // Test case for bug: parameters in event equations are ignored

--- a/test/taylor_adaptive_batch.cpp
+++ b/test/taylor_adaptive_batch.cpp
@@ -1283,7 +1283,7 @@ TEST_CASE("stream output")
             auto ta = taylor_adaptive_batch<fp_t>{{prime(x) = v - par[1], prime(v) = -9.8 * sin(x + par[0])},
                                                   {fp_t(0.), fp_t(0.01), fp_t(0.5), fp_t(0.51)},
                                                   2u,
-                                                  kw::pars = std::vector{fp_t(-1e-4), fp_t(-1.1e-4)}};
+                                                  kw::pars = std::vector{fp_t(-1e-4), fp_t(-1.1e-4), fp_t(0), fp_t(0)}};
 
             std::ostringstream oss;
 


### PR DESCRIPTION
If the pars array is empty, then zero-init it.